### PR TITLE
Fix issues running on wxPython 4.0.7.post2 | remove modifying system ui colours when not using forced dark theme

### DIFF
--- a/youtube_dl_gui/darktheme.py
+++ b/youtube_dl_gui/darktheme.py
@@ -5,9 +5,9 @@ from typing import List, Union
 
 import wx
 
-DARK_BACKGROUND_COLOUR = wx.Colour(29, 31, 33)
-DARK_FOREGROUND_COLOUR = wx.Colour(197, 200, 198)
-DARK_BACKGROUND_COLOUR_BUTTON = wx.Colour(48, 48, 49)
+DARK_BACKGROUND_COLOUR = wx.Colour(29, 31, 33, 255)
+DARK_FOREGROUND_COLOUR = wx.Colour(197, 200, 198, 255)
+DARK_BACKGROUND_COLOUR_BUTTON = wx.Colour(48, 48, 49, 255)
 
 
 def get_widgets(parent: Union[wx.Window, wx.Panel]) -> List[wx.Window]:
@@ -35,12 +35,8 @@ def dark_row_formatter(listctrl: wx.ListCtrl, dark: bool = False) -> None:
             if index % 2:
                 item.SetBackgroundColor(DARK_BACKGROUND_COLOUR)
             else:
-                item.SetBackgroundColor("Light Grey")
-        else:
-            if index % 2:
-                item.SetBackgroundColor("Light Blue")
-            else:
-                item.SetBackgroundColor("Yellow")
+                # Light Grey
+                item.SetBackgroundColor(wx.Colour(240, 240, 240, 255))
 
         listctrl.SetItem(item)
 
@@ -60,14 +56,5 @@ def dark_mode(parent: Union[wx.Window, wx.Panel], _dark_mode: bool = False) -> N
                 dark_row_formatter(widget, dark=True)
             elif isinstance(widget, wx.Button):
                 widget.SetBackgroundColour(DARK_BACKGROUND_COLOUR_BUTTON)
-        else:
-            if isinstance(widget, wx.ListCtrl):
-                dark_row_formatter(widget)
-                widget.SetBackgroundColour("White")
-                widget.SetForegroundColour("Black")
-                continue
-
-            widget.SetBackgroundColour(wx.NullColour)
-            widget.SetForegroundColour("Black")
 
     parent.Refresh()


### PR DESCRIPTION
Context: I'm writing packaging descriptions for yt-dlg for Arch User Repository, and I had issues using the package with the system libraries plus theming issues with dark system themes.

Changes:
* On wxPython 4.0.7.post2 (at least on Arch Linux) when buttons are clicked it will throw errors that the Colours are wrong. You have to click them twice to work. Alpha must be specified for all Colours when setting them.
* System theme is used correctly in wxPython, so overriding colours with no dark_theme set is unnecessary and causing issues when the system theme is dark theme, so I removed lines setting colours when dark_theme is not set. Regressions:
   * Different colour for every second row is not in place anymore
   * Text input colour and some other elements are white with light system theme and forced dark theme (probably not introduced here)
   * When changing system theme from light to dark the Download list colour doesn't change to dark. It's correct after restart (probably not introduced with this PR either, but I didn't test it).

I'm happy to make changes and when I have some more time I'll have a look at the regressions as well.