### PR TITLE
Fix issue where the cmd tools could not be executed because of permision issues on Linux

### DIFF
--- a/youtube_dl_gui/updatemanager.py
+++ b/youtube_dl_gui/updatemanager.py
@@ -10,6 +10,9 @@ Attributes:
 
 
 import json
+import os
+from sys import platform
+import stat
 from pathlib import Path
 from threading import Thread
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -112,6 +115,12 @@ class UpdateThread(Thread):
 
             with open(destination_file, "wb") as dest_file:
                 dest_file.write(stream.read())
+
+            # Have to set the executable flag on linux
+            if platform == "linux":
+                mode = os.stat(destination_file).st_mode
+                mode |= mode | stat.S_IEXEC
+                os.chmod(destination_file, mode )
 
             self._talk_to_gui("correct")
         except (HTTPError, URLError, IOError) as error:


### PR DESCRIPTION
On linux after running videos could not be downloaded for me, I figured it out on updating the executables didn't have executable permissions, exiting the process instantly.

Added a check for linux to add executable flag when downloading the files.