### PR TITLE
Fix issue when stopping downloads would crash when dl process has already been exited

### DIFF
--- a/youtube_dl_gui/downloaders.py
+++ b/youtube_dl_gui/downloaders.py
@@ -216,8 +216,10 @@ class YoutubeDLDownloader:
                 # method
                 self._proc.returncode = 0
             else:
-                # TODO: Test in Unix os.killpg ?
-                os.killpg(self._proc.pid, signal.SIGKILL)  # type: ignore
+                try:
+                    os.killpg(self._proc.pid, signal.SIGKILL)  # type: ignore
+                except ProcessLookupError:
+                    pass
 
             self._set_returncode(self.STOPPED)
 


### PR DESCRIPTION
Almost there.

On my linux machine when I stop the download midway it comes up with and error that the process has already exited when it's trying to kill the process.

Now I tried to find why it's exiting before we are actually killing the process (maybe the consequence of the lines before), tried using `os.kill` or `self._proc.kill()` but they did not produce consistent results because the process exits somewhere else before.

So this is possibly a workaround, but even with a proper fix this try/catch doesn't hurt because it only checks for a case that should have been handled.

I can add some log line instead of a `pass` on the exception to make it obvious if it happened instead.


Edit: Lines here https://github.com/oleksis/youtube-dl-gui/blob/ea358e06b42142f016d41afc7d039c69832b012a/youtube_dl_gui/downloaders.py#L206 makes the process terminate before we actually killing them. I don't want to move them because I won't test their behavior on Windows, it's up to you.