### PR TITLE
Check and fallback to "en" to init wx.Locale

### DIFF
--- a/youtube_dl_gui/app.py
+++ b/youtube_dl_gui/app.py
@@ -105,7 +105,9 @@ class BaseApp(wx.App):
             "zh_TW": wx.LANGUAGE_CHINESE_TRADITIONAL,
         }
 
-        selLang: int = supLang.get(lang, wx.LANGUAGE_ENGLISH_US)
+        selLang: int = supLang.get(lang, wx.LANGUAGE_ENGLISH)
+        if not wx.Locale.IsAvailable(selLang):
+            selLang = wx.LANGUAGE_ENGLISH
 
         if self.locale:
             assert sys.getrefcount(self.locale) <= 2

--- a/youtube_dl_gui/app.py
+++ b/youtube_dl_gui/app.py
@@ -106,8 +106,6 @@ class BaseApp(wx.App):
         }
 
         selLang: int = supLang.get(lang, wx.LANGUAGE_ENGLISH)
-        if not wx.Locale.IsAvailable(selLang):
-            selLang = wx.LANGUAGE_ENGLISH
 
         if self.locale:
             assert sys.getrefcount(self.locale) <= 2


### PR DESCRIPTION
In #62, there is no locale "en_US.UTF-8" and causing wx to popup warning.