### PR TITLE
Fix deprecation warning for distutils during build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ import glob
 import os
 import sys
 import time
-from distutils import log
-from distutils.spawn import spawn
 
 from setuptools import Command, setup
+from setuptools._distutils import log
+from setuptools._distutils.spawn import spawn
 
 __packagename__ = "youtube_dl_gui"
 __packageytdlg__ = "yt_dlg"


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0632/

The warning in question:
```
DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils import log
```

This commit does not migrate from distutils just uses the copy in setuptools instead.