### PR TITLE
Fixed ambiguous translation, caused users to unwantedly reset settings

### DIFF
--- a/youtube_dl_gui/locale/es_CU/LC_MESSAGES/youtube_dl_gui.po
+++ b/youtube_dl_gui/locale/es_CU/LC_MESSAGES/youtube_dl_gui.po
@@ -333,7 +333,7 @@ msgstr "Salir"
 
 #: youtube_dl_gui/optionsframe.py:58
 msgid "Reset"
-msgstr "Reiniciar"
+msgstr "Reestablecer"
 
 #: youtube_dl_gui/optionsframe.py:59
 msgid "Close"

--- a/youtube_dl_gui/locale/es_ES/LC_MESSAGES/youtube_dl_gui.po
+++ b/youtube_dl_gui/locale/es_ES/LC_MESSAGES/youtube_dl_gui.po
@@ -334,7 +334,7 @@ msgstr "Salir"
 
 #: youtube_dl_gui/optionsframe.py:58
 msgid "Reset"
-msgstr "Reiniciar"
+msgstr "Reestablecer"
 
 #: youtube_dl_gui/optionsframe.py:59
 msgid "Close"


### PR DESCRIPTION
Reset (settings) was translated as "Reiniciar"(Restart), which caused users to click "Reiniciar" and delete current settings, instead of restarting yt-dlg. Now is unambiguously translated as "Reestablecer"(Reset).

